### PR TITLE
📤 Update curvenote submission actions

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,19 @@
+name: Create Preview Draft from PR
+on:
+  pull_request:
+    branches: ['main']
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  draft:
+    uses: curvenote/actions/.github/workflows/draft.yml@v1
+    with:
+      id-pattern-regex: '^ubcgif-(?:[a-zA-Z0-9-_]{3,40})$'
+      venue: appliedgeophysics
+      collection: publications
+      kind: article
+      path: paper
+    secrets:
+      CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
+      GITHUB: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,19 +1,14 @@
-name: curvenote
+name: Create Submission from Main
 on:
-  pull_request:
+  push:
     branches: ['main']
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write
 jobs:
-  publish:
-    uses: curvenote/actions/.github/workflows/publish.yml@v1
+  submit:
+    uses: curvenote/actions/.github/workflows/submit.yml@v1
     with:
-      monorepo: false
       id-pattern-regex: '^ubcgif-(?:[a-zA-Z0-9-_]{3,40})$'
-      enforce-single-folder: false
-      preview-label: true
-      submit-label: true
       venue: appliedgeophysics
       collection: publications
       kind: article


### PR DESCRIPTION
This PR updates the github actions to use the new Curvenote `draft` and `submit` workflows:

- On every commit in a PR to main, a "draft" is created. These are short-lived previews, not formally received by the venue, that authors may use to review their content.
- On every push to main, a "submission" is made to the venue. This submission is visible to venue editors in a "pending" state ready to be published. (Currently publishing, which promotes content to the journal site, takes place outside of github actions).

Additional info about terms can be found here: https://curvenote.com/docs/publish/glossary#schema-and-database-objects